### PR TITLE
Add ITU-T P.862.2 Corrigendum 2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pesq
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6549559.svg)](https://doi.org/10.5281/zenodo.6549559)
 [![Downloads](https://pepy.tech/badge/pesq)](https://pepy.tech/project/pesq)
 [![Downloads](https://pepy.tech/badge/pesq/month)](https://pepy.tech/project/pesq)
 
@@ -119,6 +120,24 @@ The original C source code is modified.
 # Who is using `pesq`
 
 Please click [here](https://github.com/ludlows/python-pesq/network/dependents) to see these repositories, whose owners include `Facebook Research`, `SpeechBrain`, `NVIDIA` .etc.
+
+# Cite this code
+
+```
+   @software{miao_wang_2022_6549559,
+   author       = {Miao Wang and
+                  Christoph Boeddeker and
+                  Rafael G. Dantas and
+                  ananda seelan},
+   title        = {{ludlows/python-pesq: supporting for 
+                   multiprocessing features}},
+   month        = may,
+   year         = 2022,
+   publisher    = {Zenodo},
+   version      = {v0.0.4},
+   doi          = {10.5281/zenodo.6549559},
+   url          = {https://doi.org/10.5281/zenodo.6549559}}
+```
 
 # Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ print(pesq(rate, ref, deg, 'wb'))
 print(pesq(rate, ref, deg, 'nb'))
 ```
 
-# Usage for batch version
+# Usage for `multiprocessing` feature
 
 ```python
 def pesq_batch(fs, ref, deg, mode='wb', n_processor=None, on_error=PesqError.RAISE_EXCEPTION):

--- a/README.md
+++ b/README.md
@@ -111,12 +111,8 @@ Please click [here](https://github.com/ludlows/python-pesq/network/dependents) t
 
 ```
    @software{miao_wang_2022_6549559,
-   author       = {Miao Wang and
-                  Christoph Boeddeker and
-                  Rafael G. Dantas and
-                  ananda seelan},
-   title        = {{ludlows/python-pesq: supporting for 
-                   multiprocessing features}},
+   author       = {Miao Wang, Christoph Boeddeker, Rafael G. Dantas and ananda seelan},
+   title        = {PESQ (Perceptual Evaluation of Speech Quality) Wrapper for Python Users},
    month        = may,
    year         = 2022,
    publisher    = {Zenodo},

--- a/README.md
+++ b/README.md
@@ -13,15 +13,6 @@ This code is designed for numpy array specially.
     numpy
     cython
 
-# Build and Install
-```bash
-$ git clone https://github.com/ludlows/python-pesq.git
-$ cd python-pesq
-$ pip install .  # for python 2
-$ pip3 install . # for python 3 
-$ cd ..
-$ rm -rf python-pesq # remove the code folder since it exists in the python package folder
-```
 
 # Install with pip
 
@@ -29,13 +20,8 @@ $ rm -rf python-pesq # remove the code folder since it exists in the python pack
 # PyPi Repository
 $ pip install pesq
 
-
 # The Latest Version
 $ pip install https://github.com/ludlows/python-pesq/archive/master.zip
-
-# or
-
-$ pip3 install https://github.com/ludlows/python-pesq/archive/master.zip
 ```
 
 # Usage for narrowband and wideband Modes

--- a/pesq/__init__.py
+++ b/pesq/__init__.py
@@ -4,3 +4,5 @@
 
 from ._pesq import pesq, pesq_batch
 from ._pesq import PesqError, InvalidSampleRateError, OutOfMemoryError, BufferTooShortError, NoUtterancesError
+__all__ = ['pesq', 'pesq_batch',
+           'PesqError', 'InvalidSampleRateError', 'OutOfMemoryError', 'BufferTooShortError', 'NoUtterancesError']

--- a/pesq/pesqmain.h
+++ b/pesq/pesqmain.h
@@ -253,10 +253,10 @@ long WB_InIIR_Nsos;
 float * WB_InIIR_Hsos;
 long WB_InIIR_Nsos_8k = 1L;
 float WB_InIIR_Hsos_8k[LINIIR] = {
-    2.6657628f,  -5.3315255f,  2.6657628f,  -1.8890331f,  0.89487434f };
+    0.251188 * 2.6657628f,  0.251188 * -5.3315255f,  0.251188 * 2.6657628f,  -1.8890331f,  0.89487434f };
 long WB_InIIR_Nsos_16k = 1L;
 float WB_InIIR_Hsos_16k[LINIIR] = {
-    2.740826f,  -5.4816519f,  2.740826f,  -1.9444777f,  0.94597794f };
+    0.251188 * 2.740826f,  0.251188 * -5.4816519f,  0.251188 * 2.740826f,  -1.9444777f,  0.94597794f };
 
 void pesq_measure (SIGNAL_INFO * ref_info, SIGNAL_INFO * deg_info,
     ERROR_INFO * err_info, long * Error_Flag, char ** Error_Type)


### PR DESCRIPTION
[ITU-T P.862.2 Corrigendum 2](https://www.itu.int/rec/T-REC-P.862-201803-I!Cor2/en) addresses the systematic under-prediction of subjective scores, 0.8 MOS on average. However, as far as I know (correct me if I am wrong), this corrigendum has not been added to this repository yet.

This pull request includes the changes described in Corrigendum 2 and should therefore correct the systematic offset of ITU-T P.862.2.